### PR TITLE
Handling of external links

### DIFF
--- a/lib/wikicloth/wiki_buffer/link.rb
+++ b/lib/wikicloth/wiki_buffer/link.rb
@@ -13,13 +13,12 @@ class WikiBuffer::Link < WikiBuffer
 
   def to_s
     link_handler = @options[:link_handler]
-    unless self.internal_link
-      url = "#{params[0]}".strip
-      url = 'http://' + url if url !~ /^\s*(([a-z]+):\/\/|[\?\/])/
-
-      return link_handler.external_link(url, "#{params[1]}".strip)
+    unless self.internal_link || params[0].strip !~ /^\s*(([a-z]+):\/\/|[\?\/])/
+      return link_handler.external_link("#{params[0]}".strip, "#{params[1]}".strip)
     else
       case
+      when !self.internal_link
+        return "[#{params[0]}]"        
       when params[0] =~ /^:(.*)/
         return link_handler.link_for(params[0],params[1])
       when params[0] =~ /^\s*([a-zA-Z0-9-]+)\s*:(.*)$/


### PR DESCRIPTION
Hi,

First of all, this is my first time using github and doing any git operations other than clone so apologies if I am not going about this the right way. Perhaps I should create an issue first?

I noticed that some Wikipedia pages wrap words in square brackets for formatting ("[[sic]](http://en.wikipedia.org/w/index.php?title=Sic&action=edit)", for example). wikicloth identifies these as external links and prepends them with http://.

[This page on Wikipedia](http://en.wikipedia.org/wiki/Wikipedia:External_links#How_to_link) addresses the point:

> The URL must begin with http:// or another internet protocol, such as ftp:// or news://.

The small change here adds a test to WikiBuffer::Link before being rendered to HTML and returns it to its original form if it does not begin with a protocol name. Maybe there is a way of catching this while the WikiBuffer::Link is being created but I could not see a nice way of doing this.

Best regards,
Daniel
