### PR TITLE
Embedded images with no explicit title cause exception to be thrown

### DIFF
--- a/lib/wikicloth/wiki_link_handler.rb
+++ b/lib/wikicloth/wiki_link_handler.rb
@@ -146,7 +146,7 @@ class WikiLinkHandler
       type = nil
       w = 180
       h = nil
-      title = nil
+      title = ''
       ffloat = false
 
       options.each do |x|


### PR DESCRIPTION
When a title is not explicitly defined in markup, an attempt is made to add a nil value to a string.

Example from [Wikipedia](http://en.wikipedia.org/wiki/Coordinate_system):
    [[Image:Rectangular coordinates.svg|left|thumb|250px]]

The commit here simply changes nil to an empty string so the HTML contains a blank title if none is specified.
