### PR TITLE
Fixes broken references on Ruby v1.9.x

### DIFF
--- a/lib/wikicloth/extensions/references.rb
+++ b/lib/wikicloth/extensions/references.rb
@@ -40,7 +40,7 @@ module WikiCloth
         1.upto(r[:count]) { |x| ret += "<a href=\"#cite_ref-#{ref_name}#{ref_count}-#{x-1}\">" +
                 (r[:count] == 1 ? "^" : (x-1).to_s(26).tr('0-9a-p', 'a-z')) + "</a> " }
         ret += "</b> #{r[:value]}</li>"
-      }.to_s
+      }.join("\n")
       "<ol>#{refs}</ol>"
     end
 


### PR DESCRIPTION
Calling to_s on an array containing strings results in different output on Ruby v1.8 and v1.9:

``` bash
% rvm all do ruby -e 'puts ["foo", "bar", "baz"].to_s'
foobarbaz
["foo", "bar", "baz"]
```

But `join` works the same:

``` bash
% rvm all do ruby -e 'puts ["foo", "bar", "baz"].join(" ")'
foo bar baz
foo bar baz
```

So I changed the `to_s` to `join("\n")`.
