### PR TITLE
Don't overwrite I18n.locale (see #58)

### DIFF
--- a/lib/wikicloth.rb
+++ b/lib/wikicloth.rb
@@ -60,11 +60,11 @@ module WikiCloth
     end
 
     def render(opt={})
-      self.options = { :noedit => false, :locale => I18n.default_locale, :fast => true, :output => :html, :link_handler => self.link_handler, 
+      self.options = { :noedit => false, :fast => true, :output => :html, :link_handler => self.link_handler, 
 	:params => self.params, :sections => self.sections }.merge(self.options).merge(opt)
       self.options[:link_handler].params = options[:params]
 
-      I18n.locale = self.options[:locale]
+      I18n.locale = self.options[:locale] if self.options[:locale]
 
       data = self.sections.collect { |s| s.render(self.options) }.join
       data.gsub!(/<!--(.|\s)*?-->/,"")


### PR DESCRIPTION
Unless the parser was initialized explicitly with the current
locale, it would clobber the current I18n.locale setting. This
change respects locale if it is passed (still overwriting
I18n.locale in the process) but does nothing if it is not; the
parser will use whatever I18n.locale is already in effect.