### PR TITLE
readme: Remove mention of Wikimedia where it should say MediaWiki

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -8,7 +8,7 @@ h2. Supports
 * Links
 ** External Links [ ... ]
 ** Internal Links, Images &#91;[ ... ]]
-* Wikimedia Markup
+* Markup
 ** == Headings ==
 ** Lists (*#;:)
 ** bold (<code>'''</code>), italic (<code>''</code>) or both (<code>'''''</code>)


### PR DESCRIPTION
The word seems redundant in this context.

https://www.mediawiki.org/wiki/Wiki?
