### PR TITLE
Update var.rb

### DIFF
--- a/lib/wikicloth/wiki_buffer/var.rb
+++ b/lib/wikicloth/wiki_buffer/var.rb
@@ -175,7 +175,7 @@ class WikiBuffer::Var < WikiBuffer
     when "ucfirst"
       params.first.capitalize
     when "lcfirst"
-      params.first[0,1].downcase + params.first[1..-1]
+      params.first[0,1].downcase + params.first[1..-1].to_s
     when "anchorencode"
       params.first.gsub(/\s+/,'_')
     when "plural"


### PR DESCRIPTION
FIX: C:/ruby/lib/ruby/gems/2.0.0/gems/wikicloth-0.8.0/lib/wikicloth/wiki_buffer/var.rb:178:in `+': no implicit conversion of nil into String (TypeError)
