### PR TITLE
gemfile: use HTTPS rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
Use HTTPS for the connection to rubygems.org.

This fixes a warning in bundler:

```
  The source :rubygems is deprecated because HTTP requests are insecure.
  Please change your source to 'https://rubygems.org' if possible, or
  'http://rubygems.org' if not.
```
