### PR TITLE
Makes wikicloth gem compatible with JRuby by using twitter-text-rb for autolinking  (with the option of using rinku on MRI).

### DIFF
--- a/lib/wikicloth/core_ext.rb
+++ b/lib/wikicloth/core_ext.rb
@@ -1,4 +1,8 @@
-require 'rinku'
+begin
+  require 'rinku'
+rescue LoadError
+  require 'twitter-text'
+end
 
 READ_MODE = "r:UTF-8"
 
@@ -24,8 +28,14 @@ module ExtendedString
     self.gsub(/\W+/, '-').gsub(/^-+/,'').gsub(/-+$/,'').downcase
   end
 
-  def auto_link
-    Rinku.auto_link(to_s)
+  if defined? Rinku
+    def auto_link
+      Rinku.auto_link(to_s)
+    end
+  else
+    def auto_link
+      Twitter::Autolink.auto_link(to_s)
+    end
   end
 
   def last(n)

--- a/wikicloth.gemspec
+++ b/wikicloth.gemspec
@@ -22,7 +22,7 @@ spec = Gem::Specification.new do |s|
   s.license = "MIT"
   s.add_dependency 'builder'
   s.add_dependency 'expression_parser'
-  s.add_dependency 'rinku'
+  s.add_dependency 'twitter-text'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'i18n'


### PR DESCRIPTION
Here's one solution that I think is reasonably elegant. This commit replaces `rinku` with the `twitter-text` [gem](https://github.com/twitter/twitter-text-rb) for autolinking, thereby removing the one dependency with native C extensions (which is causing issues on JRuby). However, wikicloth does check if it can find and load `rinku`, so if people have the `rinku` gem installed, `wikicloth` will use it (I haven't done any benchmarking, but I'm assuming rinku will be slightly faster than twitter-text). Does this seem like an acceptable solution to you?
