### PR TITLE
Use nokogiri to only autolink text elements. Resolves #77

### DIFF
--- a/lib/wikicloth/core_ext.rb
+++ b/lib/wikicloth/core_ext.rb
@@ -2,6 +2,7 @@ begin
   require 'rinku'
 rescue LoadError
   require 'twitter-text'
+  require 'nokogiri'
 end
 
 READ_MODE = "r:UTF-8"
@@ -34,7 +35,11 @@ module ExtendedString
     end
   else
     def auto_link
-      Twitter::Autolink.auto_link(to_s)
+      doc = Nokogiri::HTML::DocumentFragment.parse(to_s)
+      doc.xpath(".//text()").each do |node|
+        node.content = Twitter::Autolink.auto_link(node.text, :suppress_no_follow => true)
+      end
+      doc.to_html
     end
   end
 

--- a/lib/wikicloth/core_ext.rb
+++ b/lib/wikicloth/core_ext.rb
@@ -35,11 +35,11 @@ module ExtendedString
     end
   else
     def auto_link
-      doc = Nokogiri::HTML::DocumentFragment.parse(to_s)
+      doc = Nokogiri::HTML::DocumentFragment.parse(to_s.gsub(/&(lt|gt);/i) {"&amp;#{$1};"})
       doc.xpath(".//text()").each do |node|
-        node.content = Twitter::Autolink.auto_link(node.text, :suppress_no_follow => true)
+        node.replace Twitter::Autolink.auto_link_urls(node.text, :suppress_no_follow => true, :target_blank => false)
       end
-      doc.to_html
+      doc.to_s
     end
   end
 

--- a/lib/wikicloth/wiki_buffer.rb
+++ b/lib/wikicloth/wiki_buffer.rb
@@ -218,6 +218,8 @@ class WikiBuffer
         (@paragraph_open ? "</p>" : "") + gen_heading($1.length,$2)
       }
 
+      self.data = self.data.auto_link
+
       # Paragraphs
       if is_heading
         @paragraph_open = false
@@ -232,7 +234,7 @@ class WikiBuffer
         end
       end
 
-      self.params << self.data.auto_link
+      self.params << self.data
       self.data = ""
     else
       self.data << current_char

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,5 @@
-
 require 'rubygems'
-gem "test-unit", ">= 2.0.5"
-require 'active_support'
-require 'active_support/test_case'
 require 'test/unit'
+require 'active_support'
 I18n.load_path << File.join(File.dirname(__FILE__),'locales.yml')
 require File.join(File.dirname(__FILE__),'../init')

--- a/test/wiki_cloth_test.rb
+++ b/test/wiki_cloth_test.rb
@@ -51,7 +51,7 @@ class WikiClothTest < ActiveSupport::TestCase
     assert data.include?('<a href="http://www.google.com/">')
     wiki = WikiCloth::Parser.new(:data => "[https://github.com/repo/README.md README]")
     data = wiki.to_html
-    assert data.include?('https://github.com/repo/README.md')
+    assert_equal data, "\n<p><a href=\"https://github.com/repo/README.md\" target=\"_blank\">README</a></p>"
     assert data =~ /\>\s*README\s*\</
   end
 

--- a/test/wiki_cloth_test.rb
+++ b/test/wiki_cloth_test.rb
@@ -37,7 +37,7 @@ class WikiParser < WikiCloth::Parser
   end
 end
 
-class WikiClothTest < ActiveSupport::TestCase
+class WikiClothTest < Test::Unit::TestCase
 
   test "a url should be automaticly linked" do
     wiki = WikiCloth::Parser.new(:data => "\n\n\nhttp://www.google.com/")
@@ -279,7 +279,7 @@ class WikiClothTest < ActiveSupport::TestCase
   test "template vars should not be parsed inside a pre tag" do
     wiki = WikiCloth::Parser.new(:data => "<pre>{{{1}}}</pre>")
     data = wiki.to_html
-    assert data =~ /&#123;&#123;&#123;1&#125;&#125;&#125;/
+    assert data =~ /\{\{\{1\}\}\}/
   end
 
   test "[[ links ]] should not work inside pre tags" do
@@ -391,7 +391,7 @@ EOS
   end
 
   test "sanitize html" do
-    wiki = WikiParser.new(:data => "<script type=\"text/javascript\" src=\"bla.js\"></script>\n<a href=\"test.html\" onmouseover=\"alert('hello world');\">test</a>\n")
+    wiki = WikiParser.new(:data => "<pre>&lt;test</pre><script type=\"text/javascript\" src=\"bla.js\"></script>\n<a href=\"test.html\" onmouseover=\"alert('hello world');\">test</a>\n")
     data = wiki.to_html
     assert !(data =~ /<script/)
     assert !(data =~ /onmouseover/)
@@ -440,7 +440,7 @@ EOS
   test "empty item in toc" do
     wiki = WikiCloth::WikiCloth.new({:data => "__TOC__\n=A="})
     data = wiki.render
-    assert data.include?("<table id=\"toc\" class=\"toc\" summary=\"Contents\"><tr><td><div id=\"toctitle\"><h2>Table of Contents</h2></div><ul></li><li><a href=\"#A\">A</a></li></ul></td></tr></table>")
+    assert data.include?("<table id=\"toc\" class=\"toc\" summary=\"Contents\"><tr><td>\n<div id=\"toctitle\"><h2>Table of Contents</h2></div>\n<ul><li><a href=\"#A\">A</a></li></ul>\n</td></tr></table>")
   end
 
   test "pre at beginning" do
@@ -452,12 +452,12 @@ EOS
   test "toc declared as list" do
     wiki = WikiCloth::WikiCloth.new({:data => "__TOC__\n=A=\n==B==\n===C==="})
     data = wiki.render
-    assert data.include?("<table id=\"toc\" class=\"toc\" summary=\"Contents\"><tr><td><div id=\"toctitle\"><h2>Table of Contents</h2></div><ul></li><li><a href=\"#A\">A</a><ul><li><a href=\"#B\">B</a><ul><li><a href=\"#C\">C</a></li></ul></ul></ul></td></tr></table>")
+    assert data.include?("<table id=\"toc\" class=\"toc\" summary=\"Contents\"><tr><td>\n<div id=\"toctitle\"><h2>Table of Contents</h2></div>\n<ul><li>\n<a href=\"#A\">A</a><ul><li>\n<a href=\"#B\">B</a><ul><li><a href=\"#C\">C</a></li></ul>\n</li></ul>\n</li></ul>\n</td></tr></table>")
   end
 
   test "toc numbered" do
     wiki = WikiCloth::WikiCloth.new({:data => "=A=\n=B=\n==C==\n==D==\n===E===\n===F===\n====G====\n====H====\n==I==\n=J=\n=K=\n===L===\n===M===\n====N====\n====O===="})
     data = wiki.render(:noedit => true, :toc_numbered => true)
-    assert data.include?("<table id=\"toc\" class=\"toc\" summary=\"Contents\"><tr><td><div id=\"toctitle\"><h2>Table of Contents</h2></div><ul></li><li><a href=\"#A\">1 A</a></li><li><a href=\"#B\">2 B</a><ul><li><a href=\"#C\">2.1 C</a></li><li><a href=\"#D\">2.2 D</a><ul><li><a href=\"#E\">2.2.1 E</a></li><li><a href=\"#F\">2.2.2 F</a><ul><li><a href=\"#G\">2.2.2.1 G</a></li><li><a href=\"#H\">2.2.2.2 H</a></li></ul></ul><li><a href=\"#I\">2.3 I</a></li></ul><li><a href=\"#J\">3 J</a></li><li><a href=\"#K\">4 K</a><ul><ul><li><a href=\"#L\">4.1 L</a></li><li><a href=\"#M\">4.2 M</a><ul><li><a href=\"#N\">4.2.1 N</a></li><li><a href=\"#O\">4.2.2 O</a></li></ul></ul></ul></ul></td></tr></table>")
+    assert data.include?("<table id=\"toc\" class=\"toc\" summary=\"Contents\"><tr><td>\n<div id=\"toctitle\"><h2>Table of Contents</h2></div>\n<ul>\n<li><a href=\"#A\">1 A</a></li>\n<li>\n<a href=\"#B\">2 B</a><ul>\n<li><a href=\"#C\">2.1 C</a></li>\n<li>\n<a href=\"#D\">2.2 D</a><ul>\n<li><a href=\"#E\">2.2.1 E</a></li>\n<li>\n<a href=\"#F\">2.2.2 F</a><ul>\n<li><a href=\"#G\">2.2.2.1 G</a></li>\n<li><a href=\"#H\">2.2.2.2 H</a></li>\n</ul>\n</li>\n</ul>\n</li>\n<li><a href=\"#I\">2.3 I</a></li>\n</ul>\n</li>\n<li><a href=\"#J\">3 J</a></li>\n<li>\n<a href=\"#K\">4 K</a><ul><ul>\n<li><a href=\"#L\">4.1 L</a></li>\n<li>\n<a href=\"#M\">4.2 M</a><ul>\n<li><a href=\"#N\">4.2.1 N</a></li>\n<li><a href=\"#O\">4.2.2 O</a></li>\n</ul>\n</li>\n</ul></ul>\n</li>\n</ul>\n</td></tr></table>")
   end
 end

--- a/test/wiki_cloth_test.rb
+++ b/test/wiki_cloth_test.rb
@@ -55,6 +55,12 @@ class WikiClothTest < Test::Unit::TestCase
     assert data =~ /\>\s*README\s*\</
   end
 
+  test "autolinking keeps html entities intact" do
+    wiki = WikiCloth::Parser.new(:data => "<div>&amp; &gt;</div><pre>&amp; &lt;</pre> https://github.com/repo/README.md &gt; &amp;")
+    data = wiki.to_html
+    assert_equal "\n<p><div>&amp; &gt;</div><pre>&amp; &lt;</pre> <a href=\"https://github.com/repo/README.md\">https://github.com/repo/README.md</a> &gt; &amp;</p>", data
+  end
+
   test "image url override" do
     wiki = WikiCloth::Parser.new(:data => "[[Image:test.jpg]]")
     data = wiki.to_html

--- a/wikicloth.gemspec
+++ b/wikicloth.gemspec
@@ -24,6 +24,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'expression_parser'
   s.add_dependency 'twitter-text'
   s.add_dependency 'nokogiri'
+  s.add_dependency 'htmlentities'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'i18n'

--- a/wikicloth.gemspec
+++ b/wikicloth.gemspec
@@ -23,6 +23,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'builder'
   s.add_dependency 'expression_parser'
   s.add_dependency 'twitter-text'
+  s.add_dependency 'nokogiri'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'i18n'


### PR DESCRIPTION
Issue #77 is caused by auto_linking with `Twitter::Autolink`, which is not sensitive to html `<a>` tags. So it would autolink the `href` attribute of exisiting links. This PR resolves the problem by using nokogiri to parse the string to be autolinked, and apply autolinking only to `Nokogiri::Text` nodes.