### PR TITLE
extensions/source: Avoid warning about unused assigned local

### DIFF
--- a/lib/wikicloth/extensions/source.rb
+++ b/lib/wikicloth/extensions/source.rb
@@ -19,7 +19,6 @@ module WikiCloth
       highlight_path = @options[:highlight_path] || '/usr/bin/highlight'
       highlight_options = @options[:highlight_options] || '--inline-css'
 
-      name = buffer.element_name
       content = buffer.element_content
       content = $1 if content =~ /^\s*\n(.*)$/m
       error = nil


### PR DESCRIPTION
This PR removes an unused line of code to avoid a Ruby warning being emitted.

> /home/travis/.rvm/gems/ruby-2.4.1/gems/wikicloth-0.8.3/lib/wikicloth/extensions/source.rb:22:
> warning: assigned but unused variable - name