### PR TITLE
extensions/math: Remove unused assigned local to avoid warning

### DIFF
--- a/lib/wikicloth/extensions/math.rb
+++ b/lib/wikicloth/extensions/math.rb
@@ -26,7 +26,6 @@ module WikiCloth
             "<img src=\"#{File.join(@options[:blahtex_html_prefix],"#{file_md5}.png")}\" />"
           else
             # render as mathml
-            html = xml_response.elements["mathml/markup"].text
             "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">#{xml_response.elements["mathml/markup"].children.to_s}</math>"
           end
         rescue => err


### PR DESCRIPTION
This PR removes a line of code to avoid Ruby emitting a warning:

> /home/travis/.rvm/gems/ruby-2.4.1/gems/wikicloth-0.8.3/lib/wikicloth/extensions/math.rb:29:
> warning: assigned but unused variable - html

The `git blame` history has a 2-month interval between commits on this line (old) and the next line (newer). This line is no longer used.