### PR TITLE
handle definition lists correctly, they belong in the same <dl>

### DIFF
--- a/lib/wikicloth/wiki_buffer.rb
+++ b/lib/wikicloth/wiki_buffer.rb
@@ -397,7 +397,7 @@ class WikiBuffer
 
         common = 0
         (0..last.length - 1).each do |i|
-          if last[i] == pieces[i]
+          if list_tag_for(last[i]) == list_tag_for(pieces[i])
             common += 1
           else
             break
@@ -412,7 +412,7 @@ class WikiBuffer
         end
         if open == '' && pieces != ''
           if last != ''
-            ret << "</#{list_inner_tag_for(pieces[-1,1])}>"
+            ret << "</#{list_inner_tag_for(last[-1,1])}>"
           end
           ret << "<#{list_inner_tag_for(pieces[-1,1])}>"
         end

--- a/test/wiki_cloth_test.rb
+++ b/test/wiki_cloth_test.rb
@@ -379,6 +379,13 @@ EOS
     assert_equal count.to_s, "6"
   end
 
+  test "definition lists" do
+    wiki = WikiParser.new(:data => ";definition term\n:definition data")
+    data = wiki.to_html
+    puts data
+    assert data.include?("<dl><dt>definition term</dt><dd>definition data</dd></dl>")
+  end
+
   test "noinclude and includeonly tags" do
     wiki = WikiParser.new(:data => "<noinclude>main page</noinclude><includeonly>never seen</includeonly>{{noinclude}}\n")
     data = wiki.to_html


### PR DESCRIPTION
Previously a `<dl>` would open and close around each `<dt> `and `<dd>`, since they weren't considered part of the same list. Now the check should handle this correctly and close the list when appropriate.
Please let me know, if you need anything else to get this merged, as I am really interested in getting this upstream :+1: 