### PR TITLE
add a condition to avoid FrozenError

### DIFF
--- a/lib/wikicloth/wiki_buffer/var.rb
+++ b/lib/wikicloth/wiki_buffer/var.rb
@@ -80,7 +80,7 @@ class WikiBuffer::Var < WikiBuffer
 
         ret = @options[:link_handler].include_resource(key,key_options).to_s
 
-        ret.gsub!(/<!--(.|\s)*?-->/,"")
+        ret.gsub!(/<!--(.|\s)*?-->/,"") unless ret.frozen?
         count = 0
         tag_attr = key_options.collect { |p|
           if p.instance_of?(Hash)

--- a/wikicloth.gemspec
+++ b/wikicloth.gemspec
@@ -16,7 +16,6 @@ spec = Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_path = "lib"
   s.description = File.read("README")
-  s.has_rdoc = false
   s.extra_rdoc_files = ["README","MIT-LICENSE"]
   s.description = %q{mediawiki parser}
   s.license = "MIT"


### PR DESCRIPTION
nil.to_s in Ruby 2.7.0 now always return a frozen String ""
a=nil.to_s
a.gsub!(//,'')
will raise a FrozenError (can't modify frozen String: "")