### PR TITLE
Travis: install required IDN library make the build run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1.0
   - 2.0.0
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install libidn11-dev
+addons:
+  apt:
+    packages:
+    - libidn11-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
+language: ruby
+
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install libidn11-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.7
+  - 2.6
+  - 2.5
   - 2.1.0
+  - 2.0.0
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ addons:
   apt:
     packages:
     - libidn11-dev
+
+cache: bundler


### PR DESCRIPTION
This PR improves the CI:

* the `idn-ruby` gem requires the GNU IDN library to be installed.  the package `libidn11-dev` provides the necessary components
* extend the build matrix to in-support Ruby versions
* add Bundler cache

This change was inspired by https://github.com/ashmaroli/addressable/blob/a72d2d53f1e9e8b276a6f5bc4e09b0bd63330714/.travis.yml

---

This makes the build run 🏃 , but #97 is required to make 2.7 pass. 🔧 