### PR TITLE
Remove URI.escape (deprecated in Ruby 3.0)

### DIFF
--- a/lib/wikicloth/extensions/math.rb
+++ b/lib/wikicloth/extensions/math.rb
@@ -34,7 +34,7 @@ module WikiCloth
         end
       else
         # if blahtex does not exist fallback to google charts api
-        encoded_string = URI.escape(buffer.element_content, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+        encoded_string = URI.encode_www_form_component(buffer.element_content)
         "<img src=\"https://chart.googleapis.com/chart?cht=tx&chl=#{encoded_string}\" />"
       end
     end

--- a/lib/wikicloth/wiki_buffer/var.rb
+++ b/lib/wikicloth/wiki_buffer/var.rb
@@ -167,7 +167,7 @@ class WikiBuffer::Var < WikiBuffer
       @options[:params][params.first] = params[1]
       ""
     when "urlencode"
-      URI.escape(params.first, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+      URI.encode_www_form_component(params.first)
     when "lc"
       params.first.downcase
     when "uc"


### PR DESCRIPTION
Fixes unit tests on Ruby 3.0.0.