### PR TITLE
FIX deprecated Uri.escape method

### DIFF
--- a/lib/wikicloth/wiki_buffer/var.rb
+++ b/lib/wikicloth/wiki_buffer/var.rb
@@ -167,7 +167,7 @@ class WikiBuffer::Var < WikiBuffer
       @options[:params][params.first] = params[1]
       ""
     when "urlencode"
-      URI.escape(params.first, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+      URI::Parser.new.escape(params.first, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
     when "lc"
       params.first.downcase
     when "uc"


### PR DESCRIPTION
Using wikicloth since at least ruby-2.7.6p219 (that's my current version and the one I realized it with) triggers the following warning:

    ~/.gem/ruby/2.7.0/gems/wikicloth-0.8.3/lib/wikicloth/wiki_buffer/var.rb:170: warning: URI.escape is obsolete

This method has been replaced with `Uri::Parser#escape`, which essentially does the same thing.